### PR TITLE
v0.4.4 - Create Login Token

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rackmail"
-version = "0.3.4"
+version = "0.4.4"
 description = "CLI tool for managing Rackspace hosted mailboxes"
 authors = [{ name = "Zack Farmer", email = "zackfarmer1710@gmail.com" }]
 readme = "README.md"

--- a/src/rackmail/main.py
+++ b/src/rackmail/main.py
@@ -5,6 +5,7 @@ from .subcommands.disable_user import disable_user
 from .subcommands.get_mailbox import get_mailbox
 from .subcommands.set_property import set_property
 from .subcommands.set_password import set_password
+from .subcommands.create_login_token import create_login_token
 
 def main():
     main_parser = argparse.ArgumentParser(prog="rackmail",description="CLI to interact with Rackspace's Hosted Email API",)
@@ -28,6 +29,10 @@ def main():
     change_password_subcommand = subparsers.add_parser("setpassword",help="Sets the password of a mailbox",parents=[global_command_parser])
     change_password_subcommand.add_argument("-p","--password",action="store",metavar="password",dest="password",help="The password you want set on a mailbox",required=False,default=None)
     change_password_subcommand.set_defaults(func=set_password)
+
+    token_subcommand = subparsers.add_parser("createlogintoken",help="Creates a login token for a mailbox for SSO or viewing.",parents=[global_command_parser])
+    token_subcommand.add_argument("-w","--webmail",help="Your custom webmail address",metavar="webmail_url",dest="webmail_url")
+    token_subcommand.set_defaults(func=create_login_token)
 
     set_subcommand = subparsers.add_parser(
         "set",

--- a/src/rackmail/subcommands/create_login_token.py
+++ b/src/rackmail/subcommands/create_login_token.py
@@ -1,0 +1,39 @@
+from ..client import RackspaceClient
+from ..utils.output_json import output_json
+from requests import post
+from os import environ
+
+def create_login_token(args):
+    rackspace_client = RackspaceClient()
+
+    url = f"https://api.emailsrvr.com/v1/customers/{rackspace_client.customer_id}/domains/{args.domain}/rs/mailboxes/{args.email}/logintoken"
+    request = post(url,headers=RackspaceClient().auth_header)
+    response = request.json()
+
+    print(environ.get("RACKSPACE_WEBMAIL_URL"))
+
+    if args.webmail_url or environ.get("RACKSPACE_WEBMAIL_URL"):
+        if request.status_code == 200:
+            webmail_url_unsanitized = args.webmail_url or environ.get("RACKSPACE_WEBMAIL_URL")
+            webmail_url = _strip_protocol_prefix(webmail_url_unsanitized)
+            response["desktopUrl"] = f"https://{webmail_url}/mail/src/redirect.php?user_name={args.email}@{args.domain}&emailaddress={args.email}@{args.domain}&sessionID={response.get("token")}"
+            response["mobileUrl"] = f"https://{webmail_url}/mobile/login.php?user_name={args.email}@{args.domain}&emailaddress={args.email}@{args.domain}&sessionID={response.get("token")}"
+    else:
+        response["desktopUrl"] = f"No Webmail URL Found"
+        response["mobileUrl"] = f"No Webmail URL Found"
+
+    print(
+        output_json(
+            request.status_code,
+            args.command,
+            f"{args.email}@{args.domain}",
+            response if request.status_code == 200 else request.text)
+        )
+    
+def _strip_protocol_prefix(webmail_url):
+    if "https://" in webmail_url:
+        return webmail_url.strip("https://")
+    elif "http://" in webmail_url:
+        return webmail_url.strip("https://")
+    else:
+        return webmail_url

--- a/src/rackmail/version.py
+++ b/src/rackmail/version.py
@@ -1,1 +1,1 @@
-VERSION="0.3.4"
+VERSION="0.4.4"


### PR DESCRIPTION
# Pull Request Template

## Description

Created the createlogintoken subcommand. This will allow you to create a SSO token for a mailbox with a single subcommand. Optionally, you can add -w, --webmail arguments or RACKSPACE_WEBMAIL_URL to your environment and it will pop out a fully functional SSO link.

## Related Issue

#24 

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [X] My code follows the project’s style guidelines
- [X] I have performed a self-review of my own code
- [] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Commit Message

- Created CreateLoginToken subcommand
  - Subcommand added --webmail or -w arguments for the URL of rackspace tenant webmail
  - You can add it as an argument or it will pickup from your environment.
  - Returns the desktop and mobile URLs.
  - If you put the protocol (http or https) it will strip it out so the links santize correctly
- Updated version in version.py
- Updated version in pyproject.toml
